### PR TITLE
Basic xarf:plain writing support, with experimental mapping for malware

### DIFF
--- a/intelmq-mailgen
+++ b/intelmq-mailgen
@@ -219,12 +219,6 @@ def format_malware_as_xarf(events):
     return ("all-yaml-reports.txt", contents, "text", "plain")
 
 
-known_formats = {
-    ("csv", "malware"): (malware_columns, format_malware_as_csv),
-    ("xarf", "malware"): (malware_columns, format_malware_as_xarf),
-    }
-
-
 def format_event_data(cur, outgoing_format, classification_type, event_ids):
     format_spec = known_formats.get((outgoing_format, classification_type))
     if format_spec is not None:
@@ -261,25 +255,13 @@ def create_mail(sender, recipient, subject, body, attachments):
     return msg
 
 
-def create_mails(cur, notification, config):
-    """Create one or several email objects for a notification.
-
-    Depending on the classification_type and format
-    does the formatting and returns one or several email objects.
-
-    :param config: script configuration
-    :param notification: the notification to create mails for
-    :param cur. database cursor to use when loading event information
-
-    :returns: list of email objects with len >=1
-    :rtype: list
-
-    """
+def mail_format_malware_as_xarf(cur, notification, config):
     attachments = []
-    event_attachment = format_event_data(
-        cur, notification["format"],
-        notification["classification_type"],
-        notification["event_ids"])
+
+    event_attachment = format_malware_as_xarf(
+                load_events(cur, malware_columns, notification["event_ids"])
+                )
+
     if event_attachment is not None:
         attachments.append(event_attachment)
 
@@ -291,6 +273,64 @@ def create_mails(cur, notification, config):
                                   subject=subject, body=body,
                                   attachments=attachments)
     return [mail]
+
+
+def mail_format_malware_as_csv(cur, notification, config):
+    attachments = []
+
+    event_attachment = format_malware_as_csv(
+                load_events(cur, malware_columns, notification["event_ids"])
+                )
+
+    if event_attachment is not None:
+        attachments.append(event_attachment)
+
+    subject, body = read_template(config["template_dir"],
+                                  notification["template"])
+
+    mail = create_mail(sender=config["sender"],
+                                  recipient=notification["email"],
+                                  subject=subject, body=body,
+                                  attachments=attachments)
+    return [mail]
+
+
+known_formatters = {
+    ("csv", "malware"):  mail_format_malware_as_csv,
+    ("xarf", "malware"): mail_format_malware_as_xarf,
+    }
+
+
+def create_mails(cur, notification, config):
+    """Create one or several email objects for a notification.
+
+    Depending on the classification_type and format
+    does the formatting and returns one or several email objects.
+
+    :param config: script configuration
+    :param notification: the notification to create mails for
+    :param cur: database cursor to use when loading event information
+
+    :returns: list of email objects with len >=1
+    :rtype: list
+
+    """
+
+    emails = []
+    formatter =  known_formatters.get((notification["format"],
+                                    notification["classification_type"]))
+    if formatter is not None:
+        emails = formatter(cur, notification, config)
+    else:
+        msg = ("Cannot generate emails for combination (%r, %r)" %
+                (notification["format"], notification["classification_type"]))
+        print(msg, file=sys.stderr)
+        raise NotImplementedError(msg)
+
+    return emails
+
+
+
 
 def send_notifications(config, notifications, cur):
     """

--- a/intelmq-mailgen
+++ b/intelmq-mailgen
@@ -2,12 +2,17 @@
 # -*- coding: utf-8 -*-
 
 """Command line tool to send notfications for intelmq events.
+
+Authors:
+    TODO
+    Bernhard E. Reiter <bernhard@intevation.de>
 """
 
 import smtplib
 import argparse
 import json
 import locale
+import logging
 import os
 import sys
 import io
@@ -30,6 +35,14 @@ if locale.getpreferredencoding() != 'UTF-8':
     print(red('The preferred encoding of your locale setting is not UTF-8 but'
               '{}. Exiting.'.format(locale.getpreferredencoding())))
     exit(1)
+
+
+logging.basicConfig(
+            format='%(asctime)s %(name)s %(levelname)s - %(message)s'
+        )
+logger = logging.getLogger('intelmq-mailgen')
+#logger.setLevel(logging.DEBUG)  # defaults to WARNING
+
 
 
 APPNAME = "intelmq-mailgen"
@@ -119,8 +132,6 @@ def read_template(template_dir, template_name):
         body = infile.read().strip() + "\n"
         return subject, body
 
-
-
 # characters allowed in identifiers in escape_sql_identifier. There are
 # just the characters that are used in IntelMQ for identifiers in the
 # events table.
@@ -135,110 +146,98 @@ def escape_sql_identifier(ident):
 
 
 def load_events(cur, columns, event_ids):
-    sql_columns = ", ".join(escape_sql_identifier(col) for col in columns)
-    cur.execute("SELECT {} FROM events WHERE id = ANY (%s)".format(sql_columns),
-                (event_ids,))
+    if columns:
+        sql_columns = ", ".join(escape_sql_identifier(col) for col in columns)
+        cur.execute("SELECT {} FROM events WHERE id = ANY (%s)".format(
+                    sql_columns),(event_ids,))
+    else:
+        cur.execute("SELECT * FROM events WHERE id = ANY (%s)", (event_ids,))
     return cur.fetchall()
 
 
-malware_columns = [
-    "source.asn", "source.ip", "time.source",
-    "malware.name", "source.port", "destination.ip",
-    "destination.port", "protocol.transport",
-    "destination.fqdn",
-]
+def create_malware_xarf_report(e, notification, config):
 
-def format_malware_as_csv(events):
-    contents = io.StringIO()
-    writer = csv.DictWriter(contents, malware_columns, delimiter="|")
-    for event in events:
-        writer.writerow(event)
-    return ("events.csv", contents.getvalue(), "text", "csv")
+    logger.debug("xarf: creating malware report for event {}".format(e))
+    logger.warn("xarf, malware: Using experimental mapping.")
 
-def format_malware_as_xarf(events):
-    emails = [] #TODO
-    contents ='' #report all reports as yaml until we can do emails
-
-    for e in events:
-        # create a single email
-
-        params = {
-            'schema_cache' : '/tmp/',
-            'schema_url' : 'http://www.x-arf.org/schema/abuse_malware-attack_0.1.4.json',
-            'reported_from' : "meTODO@example.com", #config["sender"] ?TODO
-            'report_id' : "TODO intelmq ID", #TODO
-            'category' : 'abuse',
-            'report_type' : 'malware-attack',
-            'source' : e['source.ip'],
-            'source_type' : 'ip-address',
-            'attachment' : None,
-        }
+    params = {
+        'schema_cache' : '/tmp/',
+        'schema_url' : 'http://www.x-arf.org/schema/abuse_malware-attack_0.1.4.json',
+        'reported_from' : config["sender"],
+        'report_id' : "TODO intelmq ID", #TODO
+        'category' : 'abuse',
+        'report_type' : 'malware-attack',
+        'source' : e['source.ip'],
+        'source_type' : 'ip-address',
+        'attachment' : None,
+    }
 
 
-        if 'date' in e:
-            params['date'] = e['time.source'].isoformat(sep=' ')
-        else:
-            params['date'] = "2016" # TODO
-
-        if 'source.url' in e:
-            params['download_link'] = e['source.url']
-
-        # have to set 'attachment' e.g. 'text/plain', if 'evidence' is supplied
-
-        report = Xarf(
-            **params
-            #schema_cache='/tmp/',
-            #schema_url='http://www.x-arf.org/schema/abuse_malware-attack_0.1.4.json',
-
-            #reported_from="meTODO@example.com", #config["sender"] ?TODO
-            #report_id="TODO intelmq ID", #TODO
-            #category='abuse',
-            #report_type='malware-attack',
-            #destination_system = "enum":["real-world","honeypot","spamtrap","honeyd","nepenthes"], optional
-            #date='Jan  1 2014 02:13:35 +0100',
-            #date=e['time.source'].isoformat(sep=' '),
-            #source='83.169.54.26',
-            #source=e['source.ip'],
-            #source_type='ip-address', "enum":["ipv4","ipv6","ip-address"]
-            #source_type='ip-address',
-            #download_link= download_link, # , optional
-            #download_port= , optional
-            #malware-md5= , optional
-            #antivirus-result= , optional
-            #antivirus-vendor= requires":"Antivirus-Result"
-            #feedback-link, optional
-            #attachment=  "enum":["none","text/plain", "message/rfc822"]
-            #attachement=None, #TODO extra information, if it is there.
-            #version= , number, optional
-            #occurrences= , integer, optional
-            #tlp= "enum":["white","green","amber","red"],optional
-        )
-
-        contents += report.to_yaml()
-
-    return ("all-yaml-reports.txt", contents, "text", "plain")
-
-
-def format_event_data(cur, outgoing_format, classification_type, event_ids):
-    format_spec = known_formats.get((outgoing_format, classification_type))
-    if format_spec is not None:
-        columns, converter = format_spec
-        return converter(load_events(cur, columns, event_ids))
+    if 'date' in e:
+        params['date'] = e['time.source'].isoformat(sep=' ')
     else:
-        msg = ("Cannot generate emails for combination (%r, %r)" %
-                (outgoing_format, classification_type))
-        print(msg, file=sys.stderr)
-        raise NotImplementedError(msg)
+        params['date'] = "2016" # TODO
+
+    if 'source.url' in e:
+        params['download_link'] = e['source.url']
+
+    # have to set 'attachment' e.g. 'text/plain', if 'evidence' is supplied
+
+    report = Xarf(
+        **params
+        #schema_cache='/tmp/',
+        #schema_url='http://www.x-arf.org/schema/abuse_malware-attack_0.1.4.json',
+        # list of potential parameters (with some examples) for this schema:
+
+        #reported_from=
+        #report_id=
+        #category='abuse',
+        #report_type='malware-attack',
+        #destination_system = "enum":["real-world","honeypot","spamtrap","honeyd","nepenthes"], optional
+        #date='Jan  1 2014 02:13:35 +0100',
+        #date=
+        #source='83.169.54.26',
+        #source=e['source.ip'],
+        #source_type='ip-address', "enum":["ipv4","ipv6","ip-address"]
+        #download_link= , optional
+        #download_port= , optional
+        #malware-md5= , optional
+        #antivirus-result= , optional
+        #antivirus-vendor= requires":"Antivirus-Result"
+        #feedback-link=, optional
+        #attachment=  "enum":["none","text/plain", "message/rfc822"]
+        #attachement=
+        #version= , number, optional
+        #occurrences= , integer, optional
+        #tlp= "enum":["white","green","amber","red"],optional
+
+        #evidence= , optional would become the additional attachment
+    )
+
+    return report
 
 
-def mark_as_sent(cur, notification):
-    cur.execute("""WITH ticket AS (SELECT nextval('intelmq_ticket_seq'))
-                 UPDATE notifications
-                    SET sent_at = now(),
-                        intelmq_ticket = (SELECT * FROM ticket)
-                  WHERE id = ANY (%s);""",
-                (notification["notification_ids"],))
+def mail_format_malware_as_xarf(cur, notification, config):
+    emails = []
 
+    events = load_events(cur, None, notification["event_ids"])
+    for event in events:
+        report = create_malware_xarf_report(event, notification, config)
+
+        subject, text = read_template(config["template_dir"],
+                                  notification["template"])
+
+        xarfmail = XarfMail(
+            report,
+            mail_from = config["sender"],
+            mail_to = notification["email"],
+            subject = subject,
+            greeting = text
+            )
+
+        emails.append(xarfmail._email) # TODO fix pyxarf to be a real email obj
+
+    return emails
 
 def create_mail(sender, recipient, subject, body, attachments):
     msg = MIMEMultipart()
@@ -254,28 +253,29 @@ def create_mail(sender, recipient, subject, body, attachments):
 
     return msg
 
+malware_columns = [
+    "source.asn", "source.ip", "time.source",
+    "malware.name", "source.port", "destination.ip",
+    "destination.port", "protocol.transport",
+    "destination.fqdn",
+]
 
-def mail_format_malware_as_xarf(cur, notification, config):
-    attachments = []
+def format_malware_as_csv(events):
+    contents = io.StringIO()
+    writer = csv.DictWriter(contents, malware_columns, delimiter="|")
+    for event in events:
+        writer.writerow(event)
+    return ("events.csv", contents.getvalue(), "text", "csv")
 
-    event_attachment = format_malware_as_xarf(
-                load_events(cur, malware_columns, notification["event_ids"])
-                )
 
-    if event_attachment is not None:
-        attachments.append(event_attachment)
-
-    subject, body = read_template(config["template_dir"],
-                                  notification["template"])
-
-    mail = create_mail(sender=config["sender"],
-                                  recipient=notification["email"],
-                                  subject=subject, body=body,
-                                  attachments=attachments)
-    return [mail]
 
 
 def mail_format_malware_as_csv(cur, notification, config):
+    """Creates one email with csv attachment for malware.
+
+    :returns: list of email objects
+    :rtype: list
+    """
     attachments = []
 
     event_attachment = format_malware_as_csv(
@@ -330,6 +330,13 @@ def create_mails(cur, notification, config):
     return emails
 
 
+def mark_as_sent(cur, notification):
+    cur.execute("""WITH ticket AS (SELECT nextval('intelmq_ticket_seq'))
+                 UPDATE notifications
+                    SET sent_at = now(),
+                        intelmq_ticket = (SELECT * FROM ticket)
+                  WHERE id = ANY (%s);""",
+                (notification["notification_ids"],))
 
 
 def send_notifications(config, notifications, cur):
@@ -346,22 +353,24 @@ def send_notifications(config, notifications, cur):
     :param config script configuration
     :param notifications a list of notifications
     :param cur database cursor to use when loading event information
+
+    :returns: number of send mails
+    :rtype: int
     """
+    send_mails = 0
     with smtplib.SMTP(host=config["smtp"]["host"],
                       port=config["smtp"]["port"]) as smtp:
         for notification in notifications:
             cur.execute("SAVEPOINT sendmail;")
             try:
                 emails = create_mails(cur, notification, config)
-                #replacing
-
-                #end replacing
 
                 if len(emails)<1:
                     #TODO maybe use a user defined exception here?
                     raise RuntimeError("No emails for sending were generated!")
                 for email in emails:
                     smtp.send_message(email)
+                    send_mails += 1
 
                 mark_as_sent(cur, notification)
             except:
@@ -369,6 +378,7 @@ def send_notifications(config, notifications, cur):
                 raise
             finally:
                 cur.execute("RELEASE SAVEPOINT sendmail;")
+    return send_mails
 
 
 def get_pending_notifications(cur):
@@ -428,9 +438,9 @@ def generate_notifications_interactively(config, cur, notifications):
                 to_send.extend(pending)
                 pending = []
 
-            print("Sending %d mails... " % (len(to_send),))
-            send_notifications(config, to_send, cur)
-            print("%d mails sent. " % (len(to_send),))
+            print("Sending mails for %d entries... " % (len(to_send),))
+            send_mails = send_notifications(config, to_send, cur)
+            print("%d mails sent. " % (send_mails,))
 
 
 def generate_notifications(args, config):

--- a/intelmq-mailgen
+++ b/intelmq-mailgen
@@ -174,10 +174,10 @@ def create_malware_xarf_report(e, notification, config):
     }
 
 
-    if 'date' in e:
+    if 'time.source' in e and e['time.source']:
         params['date'] = e['time.source'].isoformat(sep=' ')
     else:
-        params['date'] = "2016" # TODO
+        params['date'] = "2016" # this is just a placeholder TODO
 
     if 'source.url' in e:
         params['download_link'] = e['source.url']

--- a/intelmq-mailgen
+++ b/intelmq-mailgen
@@ -260,6 +260,24 @@ def mark_as_sent(cur, notification):
                 (notification["notification_ids"],))
 
 
+def create_mails(cur, notification, config):
+    attachments = []
+    event_attachment = format_event_data(
+        cur, notification["format"],
+        notification["classification_type"],
+        notification["event_ids"])
+    if event_attachment is not None:
+        attachments.append(event_attachment)
+
+    subject, body = read_template(config["template_dir"],
+                                  notification["template"])
+
+    mail = create_mail(sender=config["sender"],
+                                  recipient=notification["email"],
+                                  subject=subject, body=body,
+                                  attachments=attachments)
+    return [mail]
+
 def send_notifications(config, notifications, cur):
     """
     Create and send notification mails for all items in notifications.
@@ -280,21 +298,17 @@ def send_notifications(config, notifications, cur):
         for notification in notifications:
             cur.execute("SAVEPOINT sendmail;")
             try:
-                attachments = []
-                event_attachment = format_event_data(
-                    cur, notification["format"],
-                    notification["classification_type"],
-                    notification["event_ids"])
-                if event_attachment is not None:
-                    attachments.append(event_attachment)
+                emails = create_mails(cur, notification, config)
+                #replacing
 
-                subject, body = read_template(config["template_dir"],
-                                              notification["template"])
+                #end replacing
 
-                smtp.send_message(create_mail(sender=config["sender"],
-                                              recipient=notification["email"],
-                                              subject=subject, body=body,
-                                              attachments=attachments))
+                if len(emails)<1:
+                    #TODO maybe use a user defined exception here?
+                    raise RuntimeError("No emails for sending were generated!")
+                for email in emails:
+                    smtp.send_message(email)
+
                 mark_as_sent(cur, notification)
             except:
                 cur.execute("ROLLBACK TO SAVEPOINT sendmail;")

--- a/intelmq-mailgen
+++ b/intelmq-mailgen
@@ -120,20 +120,6 @@ def read_template(template_dir, template_name):
         return subject, body
 
 
-def create_mail(sender, recipient, subject, body, attachments):
-    msg = MIMEMultipart()
-    msg.add_header("From", sender)
-    msg.add_header("To", recipient)
-    msg.add_header("Subject", subject)
-    msg.attach(MIMEText(body))
-
-    for filename, contents, maintype, subtype in attachments:
-        part = MIMEBase(maintype, subtype, filename=filename)
-        part.set_payload(contents)
-        msg.attach(part)
-
-    return msg
-
 
 # characters allowed in identifiers in escape_sql_identifier. There are
 # just the characters that are used in IntelMQ for identifiers in the
@@ -260,7 +246,35 @@ def mark_as_sent(cur, notification):
                 (notification["notification_ids"],))
 
 
+def create_mail(sender, recipient, subject, body, attachments):
+    msg = MIMEMultipart()
+    msg.add_header("From", sender)
+    msg.add_header("To", recipient)
+    msg.add_header("Subject", subject)
+    msg.attach(MIMEText(body))
+
+    for filename, contents, maintype, subtype in attachments:
+        part = MIMEBase(maintype, subtype, filename=filename)
+        part.set_payload(contents)
+        msg.attach(part)
+
+    return msg
+
+
 def create_mails(cur, notification, config):
+    """Create one or several email objects for a notification.
+
+    Depending on the classification_type and format
+    does the formatting and returns one or several email objects.
+
+    :param config: script configuration
+    :param notification: the notification to create mails for
+    :param cur. database cursor to use when loading event information
+
+    :returns: list of email objects with len >=1
+    :rtype: list
+
+    """
     attachments = []
     event_attachment = format_event_data(
         cur, notification["format"],

--- a/intelmq-mailgen
+++ b/intelmq-mailgen
@@ -358,7 +358,7 @@ def send_notifications(config, notifications, cur):
     :returns: number of send mails
     :rtype: int
     """
-    send_mails = 0
+    sent_mails = 0
     with smtplib.SMTP(host=config["smtp"]["host"],
                       port=config["smtp"]["port"]) as smtp:
         for notification in notifications:
@@ -371,7 +371,7 @@ def send_notifications(config, notifications, cur):
                     raise RuntimeError("No emails for sending were generated!")
                 for email in emails:
                     smtp.send_message(email)
-                    send_mails += 1
+                    sent_mails += 1
 
                 mark_as_sent(cur, notification)
             except:
@@ -379,7 +379,7 @@ def send_notifications(config, notifications, cur):
                 raise
             finally:
                 cur.execute("RELEASE SAVEPOINT sendmail;")
-    return send_mails
+    return sent_mails
 
 
 def get_pending_notifications(cur):
@@ -440,8 +440,8 @@ def generate_notifications_interactively(config, cur, notifications):
                 pending = []
 
             print("Sending mails for %d entries... " % (len(to_send),))
-            send_mails = send_notifications(config, to_send, cur)
-            print("%d mails sent. " % (send_mails,))
+            sent_mails = send_notifications(config, to_send, cur)
+            print("%d mails sent. " % (sent_mails,))
 
 
 def generate_notifications(args, config):

--- a/intelmq-mailgen
+++ b/intelmq-mailgen
@@ -146,12 +146,13 @@ def escape_sql_identifier(ident):
 
 
 def load_events(cur, columns, event_ids):
-    if columns:
+    if columns is not None:
         sql_columns = ", ".join(escape_sql_identifier(col) for col in columns)
-        cur.execute("SELECT {} FROM events WHERE id = ANY (%s)".format(
-                    sql_columns),(event_ids,))
     else:
-        cur.execute("SELECT * FROM events WHERE id = ANY (%s)", (event_ids,))
+        sql_columns = "*"
+    cur.execute("SELECT {} FROM events WHERE id = ANY (%s)".format(sql_columns),
+        (event_ids,))
+
     return cur.fetchall()
 
 

--- a/intelmq-mailgen
+++ b/intelmq-mailgen
@@ -37,9 +37,7 @@ if locale.getpreferredencoding() != 'UTF-8':
     exit(1)
 
 
-logging.basicConfig(
-            format='%(asctime)s %(name)s %(levelname)s - %(message)s'
-        )
+logging.basicConfig(format='%(asctime)s %(name)s %(levelname)s - %(message)s')
 logger = logging.getLogger('intelmq-mailgen')
 #logger.setLevel(logging.DEBUG)  # defaults to WARNING
 
@@ -150,8 +148,8 @@ def load_events(cur, columns, event_ids):
         sql_columns = ", ".join(escape_sql_identifier(col) for col in columns)
     else:
         sql_columns = "*"
-    cur.execute("SELECT {} FROM events WHERE id = ANY (%s)".format(sql_columns),
-        (event_ids,))
+    cur.execute("SELECT {} FROM events WHERE id = ANY (%s)".format(
+                sql_columns), (event_ids,))
 
     return cur.fetchall()
 
@@ -171,7 +169,7 @@ def create_malware_xarf_report(e, notification, config):
         'source' : e['source.ip'],
         'source_type' : 'ip-address',
         'attachment' : None,
-    }
+        }
 
 
     if 'time.source' in e and e['time.source']:
@@ -213,7 +211,7 @@ def create_malware_xarf_report(e, notification, config):
         #tlp= "enum":["white","green","amber","red"],optional
 
         #evidence= , optional would become the additional attachment
-    )
+        )
 
     return report
 
@@ -226,7 +224,7 @@ def mail_format_malware_as_xarf(cur, notification, config):
         report = create_malware_xarf_report(event, notification, config)
 
         subject, text = read_template(config["template_dir"],
-                                  notification["template"])
+                                      notification["template"])
 
         xarfmail = XarfMail(
             report,
@@ -259,7 +257,7 @@ malware_columns = [
     "malware.name", "source.port", "destination.ip",
     "destination.port", "protocol.transport",
     "destination.fqdn",
-]
+    ]
 
 def format_malware_as_csv(events):
     contents = io.StringIO()
@@ -280,8 +278,7 @@ def mail_format_malware_as_csv(cur, notification, config):
     attachments = []
 
     event_attachment = format_malware_as_csv(
-                load_events(cur, malware_columns, notification["event_ids"])
-                )
+        load_events(cur, malware_columns, notification["event_ids"]))
 
     if event_attachment is not None:
         attachments.append(event_attachment)
@@ -290,9 +287,9 @@ def mail_format_malware_as_csv(cur, notification, config):
                                   notification["template"])
 
     mail = create_mail(sender=config["sender"],
-                                  recipient=notification["email"],
-                                  subject=subject, body=body,
-                                  attachments=attachments)
+                       recipient=notification["email"],
+                       subject=subject, body=body,
+                       attachments=attachments)
     return [mail]
 
 
@@ -324,7 +321,7 @@ def create_mails(cur, notification, config):
         emails = formatter(cur, notification, config)
     else:
         msg = ("Cannot generate emails for combination (%r, %r)" %
-                (notification["format"], notification["classification_type"]))
+               (notification["format"], notification["classification_type"]))
         print(msg, file=sys.stderr)
         raise NotImplementedError(msg)
 
@@ -477,7 +474,7 @@ if __name__ == '__main__':
         usage=USAGE,
         description=DESCRIPTION,
         epilog=EPILOG,
-    )
+        )
     parser.add_argument('-a', '--all', action='store_true',
                         help='Process all events (batch mode)')
     args = parser.parse_args()

--- a/intelmq-mailgen
+++ b/intelmq-mailgen
@@ -170,8 +170,67 @@ def format_malware_as_csv(events):
     return ("events.csv", contents.getvalue(), "text", "csv")
 
 def format_malware_as_xarf(events):
-    contents = "To be implemented"
-    return ("placeholder.txt", contents, "text", "plain")
+    emails = [] #TODO
+    contents ='' #report all reports as yaml until we can do emails
+
+    for e in events:
+        # create a single email
+
+        params = {
+            'schema_cache' : '/tmp/',
+            'schema_url' : 'http://www.x-arf.org/schema/abuse_malware-attack_0.1.4.json',
+            'reported_from' : "meTODO@example.com", #config["sender"] ?TODO
+            'report_id' : "TODO intelmq ID", #TODO
+            'category' : 'abuse',
+            'report_type' : 'malware-attack',
+            'source' : e['source.ip'],
+            'source_type' : 'ip-address',
+            'attachment' : None,
+        }
+
+
+        if 'date' in e:
+            params['date'] = e['time.source'].isoformat(sep=' ')
+        else:
+            params['date'] = "2016" # TODO
+
+        if 'source.url' in e:
+            params['download_link'] = e['source.url']
+
+        # have to set 'attachment' e.g. 'text/plain', if 'evidence' is supplied
+
+        report = Xarf(
+            **params
+            #schema_cache='/tmp/',
+            #schema_url='http://www.x-arf.org/schema/abuse_malware-attack_0.1.4.json',
+
+            #reported_from="meTODO@example.com", #config["sender"] ?TODO
+            #report_id="TODO intelmq ID", #TODO
+            #category='abuse',
+            #report_type='malware-attack',
+            #destination_system = "enum":["real-world","honeypot","spamtrap","honeyd","nepenthes"], optional
+            #date='Jan  1 2014 02:13:35 +0100',
+            #date=e['time.source'].isoformat(sep=' '),
+            #source='83.169.54.26',
+            #source=e['source.ip'],
+            #source_type='ip-address', "enum":["ipv4","ipv6","ip-address"]
+            #source_type='ip-address',
+            #download_link= download_link, # , optional
+            #download_port= , optional
+            #malware-md5= , optional
+            #antivirus-result= , optional
+            #antivirus-vendor= requires":"Antivirus-Result"
+            #feedback-link, optional
+            #attachment=  "enum":["none","text/plain", "message/rfc822"]
+            #attachement=None, #TODO extra information, if it is there.
+            #version= , number, optional
+            #occurrences= , integer, optional
+            #tlp= "enum":["white","green","amber","red"],optional
+        )
+
+        contents += report.to_yaml()
+
+    return ("all-yaml-reports.txt", contents, "text", "plain")
 
 
 known_formats = {

--- a/intelmq-mailgen
+++ b/intelmq-mailgen
@@ -21,6 +21,10 @@ import psycopg2
 from psycopg2.extras import RealDictConnection
 from termstyle import red
 
+#local application/library specific imports (we depend on our special pyxarf)
+from pyxarf import Xarf
+from xarfmail import XarfMail
+
 
 if locale.getpreferredencoding() != 'UTF-8':
     print(red('The preferred encoding of your locale setting is not UTF-8 but'
@@ -165,9 +169,14 @@ def format_malware_as_csv(events):
         writer.writerow(event)
     return ("events.csv", contents.getvalue(), "text", "csv")
 
+def format_malware_as_xarf(events):
+    contents = "To be implemented"
+    return ("placeholder.txt", contents, "text", "plain")
+
 
 known_formats = {
     ("csv", "malware"): (malware_columns, format_malware_as_csv),
+    ("xarf", "malware"): (malware_columns, format_malware_as_xarf),
     }
 
 


### PR DESCRIPTION
Refactored so that a formatter can decide to create one or several emails.
Added experimental mapping support for malware and xarf (one per email).

Should be merge to master so that additional formatter support
will use the new structure (or improve on it).

Dont't forget: **Needs pyxarf 0.0.5bereiter from master branch at https://bitbucket.org/bereiter/pyxarf**