### PR TITLE
SQL: Add ON DELETE CASCADE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,20 @@
 As this component is to be used and released together with others, see
 [intelmq-cb-mailgen/NEWS](https://github.com/Intevation/intelmq-mailgen-release).
 
+## 1.3.8
+
+Add `ON DELETE CASCADE` to the foreign keys of table `directives`
+that allows deleting data from tables events and sent without manually
+deleting the corresponding entries from the directives.
+
+```sql
+ALTER TABLE directives
+    DROP CONSTRAINT directives_events_id_fkey,
+    DROP CONSTRAINT directives_sent_id_fkey,
+    ADD CONSTRAINT directives_events_id_fkey FOREIGN KEY (events_id) REFERENCES events(id) ON DELETE CASCADE,
+    ADD CONSTRAINT directives_sent_id_fkey FOREIGN KEY (sent_id) REFERENCES sent(id) ON DELETE CASCADE;
+```
+
 ## 1.3.7
 
 To use the `JSONB` type of IntelMQ's `extra` field directly without conversion, re-create these adjusted functions:

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,10 @@ intelmq-mailgen (1.3.8-2) UNRELEASED; urgency=medium
   * Raise error when scripts directory is not a directory or cannot be read.
   * Notifications: Handle NULL aggregate_identifier
   * Tableformat: Handle NULL extra
+  * SQL/Database:
+    * Add `ON DELETE CASCADE` to the foreign keys of table `directives` (#50)
+      that allows deleting data from tables events and sent without manually
+      deleting the corresponding entries from the directives.
 
  -- Sebastian Wagner <sebix@sebix.at>  Tue, 10 Jun 2025 16:06:05 +0200
 

--- a/sql/notifications.sql
+++ b/sql/notifications.sql
@@ -67,8 +67,8 @@ CREATE TABLE directives (
 
     inserted_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    FOREIGN KEY (events_id) REFERENCES events(id),
-    FOREIGN KEY (sent_id) REFERENCES sent(id)
+    FOREIGN KEY (events_id) REFERENCES events(id) ON DELETE CASCADE,
+    FOREIGN KEY (sent_id) REFERENCES sent(id) ON DELETE CASCADE
 );
 
 

--- a/sql/updates.md
+++ b/sql/updates.md
@@ -2,6 +2,16 @@
 
 (most recent on top)
 
+## Add `DROP CASCADE` to foreign keys
+
+```sql
+ALTER TABLE directives
+    DROP CONSTRAINT directives_events_id_fkey,
+    DROP CONSTRAINT directives_sent_id_fkey,
+    ADD CONSTRAINT directives_events_id_fkey FOREIGN KEY (events_id) REFERENCES events(id) ON DELETE CASCADE,
+    ADD CONSTRAINT directives_sent_id_fkey FOREIGN KEY (sent_id) REFERENCES sent(id) ON DELETE CASCADE;
+```
+
 ## Adapt to JSONB type of IntelMQ's `extra` field
 
 ```sql


### PR DESCRIPTION
that allows deleting data from tables events and sent without manually deleting the corresponding entries from the directives.

There's no value in blocking the deletion of entries in the table directives, which are obsolete anyway, when one wants to delete entries from the events table.