### PR TITLE
check if scripts directory is readable

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 intelmq-mailgen (1.3.8-2) UNRELEASED; urgency=medium
 
   * example script to add bcc contacts: handle existing parameters to mail_format_as_csv
+  * Raise error when scripts directory is not a directory or cannot be read.
 
  -- Sebastian Wagner <sebix@sebix.at>  Tue, 10 Jun 2025 16:06:05 +0200
 

--- a/intelmqmail/script.py
+++ b/intelmqmail/script.py
@@ -34,6 +34,8 @@ def load_scripts(script_directory, entry_point, logger=None):
         logger = log
     entry_points = []
     found_errors = False
+    if not os.path.isdir(script_directory) or not os.access(script_directory, os.R_OK):
+        raise ValueError(f'Scripts directory {script_directory!r} is not a directory or cannot be read!')
     glob_pattern = os.path.join(glob.escape(script_directory),
                                 "[0-9][0-9]*.py")
     for filename in sorted(glob.glob(glob_pattern)):


### PR DESCRIPTION
globbing makes no checks, so check manually if the directory is a directory and can be read

otherwise a wrong script directory parameter may go completly unnoticed