### PR TITLE
SQL: Grant the database owner privileges

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 intelmq-mailgen (1.4.1-1) UNRELEASED; urgency=medium
 
   * Locale detection: Make check case-insensitive
+  * Database: Grant the `eventdb_owner` some privileges
 
  -- Sebastian Wagner <sebix@sebix.at>  Fri, 19 Sep 2025 09:02:39 +0200
 

--- a/sql/notifications.sql
+++ b/sql/notifications.sql
@@ -19,6 +19,7 @@ CREATE ROLE eventdb_send_notifications
 ALTER DATABASE :"DBNAME" OWNER TO eventdb_owner;
 
 ALTER TABLE events OWNER TO eventdb_owner;
+GRANT ALL PRIVILEGES ON SCHEMA public TO eventdb_owner;
 
 -- must be superuser to create type
 CREATE TYPE ip_endpoint AS ENUM ('source', 'destination');

--- a/sql/updates.md
+++ b/sql/updates.md
@@ -2,6 +2,14 @@
 
 (most recent on top)
 
+## Privileges to database owner (1.4.1)
+
+This change is primarily important for new setups, executing the SQL setup script.
+Applying the change to existing installations just keeps them in sync and has no operational effects.
+```sql
+GRANT ALL PRIVILEGES ON SCHEMA public TO eventdb_owner;
+```
+
 ## Add `DROP CASCADE` to foreign keys (1.4.0)
 
 ```sql


### PR DESCRIPTION
Otherwise eventdb_owner can't create the tables in this script.